### PR TITLE
Support for matching rules in LDAP lookups

### DIFF
--- a/ldap-nss.c
+++ b/ldap-nss.c
@@ -4563,6 +4563,18 @@ _nss_ldap_map_df (const char *attribute)
   return value;
 }
 
+const char *
+_nss_ldap_map_mr (ldap_map_selector_t sel, const char *attribute)
+{
+  const char *mapped = NULL;
+  NSS_STATUS stat;
+  ldap_session_t *session = &__session;
+
+  stat = _nss_ldap_map_get (session->ls_config, sel, MAP_MATCHING_RULE, attribute, &mapped);
+
+  return (stat == NSS_SUCCESS) ? mapped : NULL;
+}
+
 NSS_STATUS
 _nss_ldap_map_put (ldap_config_t * config,
 		   ldap_map_selector_t sel,
@@ -4600,6 +4612,7 @@ _nss_ldap_map_put (ldap_config_t * config,
     case MAP_OBJECTCLASS:
     case MAP_OVERRIDE:
     case MAP_DEFAULT:
+    case MAP_MATCHING_RULE:
       break;
     default:
       return NSS_NOTFOUND;

--- a/ldap-nss.h
+++ b/ldap-nss.h
@@ -384,7 +384,7 @@ struct ldap_config
   /*
    * attribute/objectclass maps relative to this config
    */
-  void *ldc_maps[LM_NONE + 1][6]; /* must match MAP_MAX */
+  void *ldc_maps[LM_NONE + 1][7]; /* must match MAP_MAX */
 
   /*
    * is userPassword "userPassword" or not? 
@@ -561,7 +561,8 @@ enum ldap_map_type
   MAP_DEFAULT,
   MAP_ATTRIBUTE_REVERSE,
   MAP_OBJECTCLASS_REVERSE, /* XXX not used yet? */
-  MAP_MAX = MAP_OBJECTCLASS_REVERSE
+  MAP_MATCHING_RULE,
+  MAP_MAX = MAP_MATCHING_RULE
 };
 
 typedef enum ldap_map_type ldap_map_type_t;
@@ -992,6 +993,8 @@ const char *_nss_ldap_unmap_oc (ldap_map_selector_t sel, const char *pChar);
 
 const char *_nss_ldap_map_ov (const char *pChar);
 const char *_nss_ldap_map_df (const char *pChar);
+
+const char *_nss_ldap_map_mr (ldap_map_selector_t sel, const char *attribute);
 
 /*
  * Proxy bind support for AIX.

--- a/ldap-schema.c
+++ b/ldap-schema.c
@@ -35,6 +35,7 @@ static char rcsId[] =
 #include <pthread.h>
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <netdb.h>
@@ -131,6 +132,79 @@ char _nss_ldap_filt_setautomntent[LDAP_FILT_MAXSIZ];
 char _nss_ldap_filt_getautomntent[LDAP_FILT_MAXSIZ];
 char _nss_ldap_filt_getautomntbyname[LDAP_FILT_MAXSIZ];
 
+#define PUT_CHAR(c) \
+  do { \
+    if (buffer < buffer_end) \
+      *(buffer++) = c; \
+  } while (0)
+
+#define PUT_STR(str) \
+  do { \
+    char const* const s = str; \
+    size_t const s_size = strlen (s); \
+    size_t const space_left = buffer_end - buffer; \
+    size_t const copy_size = (s_size < space_left ? s_size : space_left); \
+    memcpy (buffer, s, copy_size); \
+    buffer += copy_size; \
+  } while (0)
+
+#define FILL(filter_buffer) \
+  do { \
+    char* buffer = filter_buffer; \
+    char* const buffer_end = buffer + LDAP_FILT_MAXSIZ
+
+#define FILL_END \
+    assert (buffer < buffer_end); \
+    *(buffer < buffer_end ? buffer : buffer_end - 1) = '\0'; \
+  } while (0)
+
+#define FILTER \
+  do { \
+    PUT_CHAR ('(')
+
+#define FILTER_END \
+    PUT_CHAR (')'); \
+  } while (0)
+
+#define AND_FILTER \
+  FILTER; \
+    PUT_CHAR ('&')
+
+#define OR_FILTER \
+  FILTER; \
+    PUT_CHAR ('|')
+
+#define ITEM(attr, matchingrule, filtertype, assertionvalue) \
+  do { \
+    char const* const mr = matchingrule; \
+    PUT_STR (attr); \
+    if (mr) \
+    { \
+      PUT_CHAR (':'); \
+      PUT_STR (mr); \
+      PUT_CHAR (':'); \
+    } \
+    PUT_STR (#filtertype); \
+    PUT_STR (assertionvalue); \
+  } while (0)
+
+#define ITEM_FILTER(map, at, assertionvalue) \
+  FILTER; \
+    ITEM (ATM (map, at), MRM (map, at), =, assertionvalue); \
+  FILTER_END
+
+#define FIXED_ITEM_FILTERM(map, at, oc) \
+  ITEM_FILTER (map, at, OC (oc))
+
+#define FIXED_ITEM_FILTER(at, oc) \
+  FIXED_ITEM_FILTERM (LM_NONE, at, oc)
+
+#define QUERY_ITEM_FILTERM(map, at, specifier) \
+  ITEM_FILTER (map, at, specifier)
+
+#define QUERY_ITEM_FILTER(at, specifier) \
+  QUERY_ITEM_FILTERM (LM_NONE, at, specifier)
+
 /**
  * lookup filter initialization
  */
@@ -138,137 +212,251 @@ void
 _nss_ldap_init_filters ()
 {
   /* rfc822 mail aliases */
-  snprintf (_nss_ldap_filt_getaliasbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (nisMailAlias),
-            ATM (LM_ALIASES, cn), "%s");
-  snprintf (_nss_ldap_filt_getaliasent, LDAP_FILT_MAXSIZ,
-	    "(%s=%s)", AT (objectClass), OC (nisMailAlias));
+  FILL (_nss_ldap_filt_getaliasbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, nisMailAlias);
+      QUERY_ITEM_FILTERM (LM_ALIASES, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getaliasent);
+    FIXED_ITEM_FILTER (objectClass, nisMailAlias);
+  FILL_END;
 
   /* boot parameters */
-  snprintf (_nss_ldap_filt_getbootparamsbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (bootableDevice),
-            ATM (LM_BOOTPARAMS, cn), "%d");
+  FILL (_nss_ldap_filt_getbootparamsbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, bootableDevice);
+      QUERY_ITEM_FILTERM (LM_BOOTPARAMS, cn, "%d");
+    FILTER_END;
+  FILL_END;
 
   /* MAC address mappings */
-  snprintf (_nss_ldap_filt_gethostton, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ieee802Device),
-            ATM (LM_ETHERS, cn), "%s");
-  snprintf (_nss_ldap_filt_getntohost, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(|(%s=%s)(%s=%s)))", AT (objectClass), OC (ieee802Device),
-	    AT (macAddress), "%s", AT (macAddress), "%s");
-  snprintf (_nss_ldap_filt_getetherent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (ieee802Device));
+  FILL (_nss_ldap_filt_gethostton);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ieee802Device);
+      QUERY_ITEM_FILTERM (LM_ETHERS, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getntohost);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ieee802Device);
+      OR_FILTER;
+        QUERY_ITEM_FILTER (macAddress, "%s");
+        QUERY_ITEM_FILTER (macAddress, "%s");
+      FILTER_END;
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getetherent);
+    FIXED_ITEM_FILTER (objectClass, ieee802Device);
+  FILL_END;
 
   /* groups */
-  snprintf (_nss_ldap_filt_getgrnam, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (posixGroup),
-            ATM (LM_GROUP, cn), "%s");
-  snprintf (_nss_ldap_filt_getgrgid, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (posixGroup),
-            ATM (LM_GROUP, gidNumber), "%d");
-  snprintf (_nss_ldap_filt_getgrent, LDAP_FILT_MAXSIZ, "(&(%s=%s))",
-	    AT (objectClass), OC (posixGroup));
-  snprintf (_nss_ldap_filt_getgroupsbymemberanddn, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(|(%s=%s)(%s=%s)))",
-	    AT (objectClass), OC (posixGroup), AT (memberUid), "%s", AT (uniqueMember), "%s");
-  snprintf (_nss_ldap_filt_getgroupsbydn, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))",
-	    AT (objectClass), OC (posixGroup), AT (uniqueMember), "%s");
-  snprintf (_nss_ldap_filt_getpwnam_groupsbymember, LDAP_FILT_MAXSIZ,
-	    "(|(&(%s=%s)(%s=%s))(&(%s=%s)(%s=%s)))",
-	    AT (objectClass), OC (posixGroup), AT (memberUid), "%s",
-	    AT (objectClass), OC (posixAccount), ATM (LM_PASSWD, uid), "%s");
-  snprintf (_nss_ldap_filt_getgroupsbymember, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (posixGroup), AT (memberUid),
-	    "%s");
+  FILL (_nss_ldap_filt_getgrnam);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixGroup);
+      QUERY_ITEM_FILTERM (LM_GROUP, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getgrgid);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixGroup);
+      QUERY_ITEM_FILTERM (LM_GROUP, gidNumber, "%d");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getgrent);
+    FIXED_ITEM_FILTER (objectClass, posixGroup);
+  FILL_END;
+  FILL (_nss_ldap_filt_getgroupsbymemberanddn);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixGroup);
+      OR_FILTER;
+        QUERY_ITEM_FILTER (memberUid, "%s");
+        QUERY_ITEM_FILTER (uniqueMember, "%s");
+      FILTER_END;
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getgroupsbydn);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixGroup);
+      QUERY_ITEM_FILTER (uniqueMember, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getpwnam_groupsbymember);
+    OR_FILTER;
+      AND_FILTER;
+        FIXED_ITEM_FILTER (objectClass, posixGroup);
+        QUERY_ITEM_FILTER (memberUid, "%s");
+      FILTER_END;
+      AND_FILTER;
+        FIXED_ITEM_FILTER (objectClass, posixAccount);
+        QUERY_ITEM_FILTERM (LM_PASSWD, uid, "%s");
+      FILTER_END;
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getgroupsbymember);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixGroup);
+      QUERY_ITEM_FILTER (memberUid, "%s");
+    FILTER_END;
+  FILL_END;
 
   /* IP hosts */
-  snprintf (_nss_ldap_filt_gethostbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipHost), ATM (LM_HOSTS, cn),
-            "%s");
-  snprintf (_nss_ldap_filt_gethostbyaddr, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipHost), AT (ipHostNumber),
-	    "%s");
-  snprintf (_nss_ldap_filt_gethostent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (ipHost));
+  FILL (_nss_ldap_filt_gethostbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipHost);
+      QUERY_ITEM_FILTERM (LM_HOSTS, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_gethostbyaddr);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipHost);
+      QUERY_ITEM_FILTER (ipHostNumber, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_gethostent);
+    FIXED_ITEM_FILTER (objectClass, ipHost);
+  FILL_END;
 
   /* IP networks */
-  snprintf (_nss_ldap_filt_getnetbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipNetwork),
-            ATM (LM_NETWORKS, cn), "%s");
-  snprintf (_nss_ldap_filt_getnetbyaddr, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipNetwork),
-	    AT (ipNetworkNumber), "%s");
-  snprintf (_nss_ldap_filt_getnetent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (ipNetwork));
+  FILL (_nss_ldap_filt_getnetbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipNetwork);
+      QUERY_ITEM_FILTERM (LM_NETWORKS, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getnetbyaddr);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipNetwork);
+      QUERY_ITEM_FILTER (ipNetworkNumber, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getnetent);
+    FIXED_ITEM_FILTER (objectClass, ipNetwork);
+  FILL_END;
 
   /* IP protocols */
-  snprintf (_nss_ldap_filt_getprotobyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipProtocol),
-            ATM (LM_PROTOCOLS, cn), "%s");
-  snprintf (_nss_ldap_filt_getprotobynumber, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipProtocol),
-	    AT (ipProtocolNumber), "%d");
-  snprintf (_nss_ldap_filt_getprotoent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (ipProtocol));
+  FILL (_nss_ldap_filt_getprotobyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipProtocol);
+      QUERY_ITEM_FILTERM (LM_PROTOCOLS, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getprotobynumber);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipProtocol);
+      QUERY_ITEM_FILTER (ipProtocolNumber, "%d");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getprotoent);
+    FIXED_ITEM_FILTER (objectClass, ipProtocol);
+  FILL_END;
 
   /* users */
-  snprintf (_nss_ldap_filt_getpwnam, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (posixAccount),
-            ATM (LM_PASSWD, uid), "%s");
-  snprintf (_nss_ldap_filt_getpwuid, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))",
-	    AT (objectClass), OC (posixAccount), AT (uidNumber), "%d");
-  snprintf (_nss_ldap_filt_getpwent, LDAP_FILT_MAXSIZ,
-	    "(%s=%s)", AT (objectClass), OC (posixAccount));
+  FILL (_nss_ldap_filt_getpwnam);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixAccount);
+      QUERY_ITEM_FILTERM (LM_PASSWD, uid, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getpwuid);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, posixAccount);
+      QUERY_ITEM_FILTER (uidNumber, "%d");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getpwent);
+    FIXED_ITEM_FILTER (objectClass, posixAccount);
+  FILL_END;
 
   /* RPCs */
-  snprintf (_nss_ldap_filt_getrpcbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (oncRpc), ATM (LM_RPC, cn), "%s");
-  snprintf (_nss_ldap_filt_getrpcbynumber, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (oncRpc), AT (oncRpcNumber),
-	    "%d");
-  snprintf (_nss_ldap_filt_getrpcent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (oncRpc));
+  FILL (_nss_ldap_filt_getrpcbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, oncRpc);
+      QUERY_ITEM_FILTERM (LM_RPC, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getrpcbynumber);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, oncRpc);
+      QUERY_ITEM_FILTER (oncRpcNumber, "%d");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getrpcent);
+    FIXED_ITEM_FILTER (objectClass, oncRpc);
+  FILL_END;
 
   /* IP services */
-  snprintf (_nss_ldap_filt_getservbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipService), ATM (LM_SERVICES, cn),
-            "%s");
-  snprintf (_nss_ldap_filt_getservbynameproto, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s)(%s=%s))",
-	    AT (objectClass), OC (ipService), ATM (LM_SERVICES, cn), "%s", AT (ipServiceProtocol),
-            "%s");
-  snprintf (_nss_ldap_filt_getservbyport, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (ipService), AT (ipServicePort),
-	    "%d");
-  snprintf (_nss_ldap_filt_getservbyportproto, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s)(%s=%s))", AT (objectClass), OC (ipService),
-	    AT (ipServicePort), "%d", AT (ipServiceProtocol), "%s");
-  snprintf (_nss_ldap_filt_getservent, LDAP_FILT_MAXSIZ, "(%s=%s)",
-	    AT (objectClass), OC (ipService));
+  FILL (_nss_ldap_filt_getservbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipService);
+      QUERY_ITEM_FILTERM (LM_SERVICES, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getservbynameproto);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipService);
+      QUERY_ITEM_FILTERM (LM_SERVICES, cn, "%s");
+      QUERY_ITEM_FILTER (ipServiceProtocol, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getservbyport);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipService);
+      QUERY_ITEM_FILTER (ipServicePort, "%d");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getservbyportproto);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, ipService);
+      QUERY_ITEM_FILTER (ipServicePort, "%d");
+      QUERY_ITEM_FILTER (ipServiceProtocol, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getservent);
+    FIXED_ITEM_FILTER (objectClass, ipService);
+  FILL_END;
 
   /* shadow users */
-  snprintf (_nss_ldap_filt_getspnam, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (shadowAccount),
-            ATM (LM_SHADOW, uid), "%s");
-  snprintf (_nss_ldap_filt_getspent, LDAP_FILT_MAXSIZ,
-	    "(%s=%s)", AT (objectClass), OC (shadowAccount));
+  FILL (_nss_ldap_filt_getspnam);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, shadowAccount);
+      QUERY_ITEM_FILTERM (LM_SHADOW, uid, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getspent);
+    FIXED_ITEM_FILTER (objectClass, shadowAccount);
+  FILL_END;
 
   /* netgroups */
-  snprintf (_nss_ldap_filt_getnetgrent, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (nisNetgroup),
-            ATM (LM_NETGROUP, cn), "%s");
-  snprintf (_nss_ldap_filt_innetgr, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (nisNetgroup), AT (memberNisNetgroup), "%s");
+  FILL (_nss_ldap_filt_getnetgrent);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, nisNetgroup);
+      QUERY_ITEM_FILTERM (LM_NETGROUP, cn, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_innetgr);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, nisNetgroup);
+      QUERY_ITEM_FILTER (memberNisNetgroup, "%s");
+    FILTER_END;
+  FILL_END;
 
   /* automounts */
-  snprintf (_nss_ldap_filt_setautomntent, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (automountMap), AT (automountMapName), "%s");
-  snprintf (_nss_ldap_filt_getautomntent, LDAP_FILT_MAXSIZ,
-	    "(%s=%s)", AT (objectClass), OC (automount));
-  snprintf (_nss_ldap_filt_getautomntbyname, LDAP_FILT_MAXSIZ,
-	    "(&(%s=%s)(%s=%s))", AT (objectClass), OC (automount), AT (automountKey), "%s");
+  FILL (_nss_ldap_filt_setautomntent);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, automountMap);
+      QUERY_ITEM_FILTER (automountMapName, "%s");
+    FILTER_END;
+  FILL_END;
+  FILL (_nss_ldap_filt_getautomntent);
+    FIXED_ITEM_FILTER (objectClass, automount);
+  FILL_END;
+  FILL (_nss_ldap_filt_getautomntbyname);
+    AND_FILTER;
+      FIXED_ITEM_FILTER (objectClass, automount);
+      QUERY_ITEM_FILTER (automountKey, "%s");
+    FILTER_END;
+  FILL_END;
 }
 
 static void init_pwd_attributes (const char ***pwd_attrs);

--- a/ldap-schema.h
+++ b/ldap-schema.h
@@ -117,6 +117,8 @@ extern char _nss_ldap_filt_getautomntbyname[];
 #define ATM(map, at)             _nss_ldap_map_at(map, AT##_##at)
 #define DF(at)                   _nss_ldap_map_df(at)
 #define OV(at)                   _nss_ldap_map_ov(at)
+#define MR(at)                   _nss_ldap_map_mr(LM_NONE, AT##_##at)
+#define MRM(map, at)             _nss_ldap_map_mr(map, AT##_##at)
 
 /**
  * Common attributes, not from RFC 2307.

--- a/nss_ldap.5
+++ b/nss_ldap.5
@@ -452,6 +452,27 @@ If
 was built without schema mapping support, then this option
 is ignored.
 .TP
+.B nss_matching_rule <attribute> <matching_rule>
+This option may be specified multiple times, and directs
+.B nss_ldap
+to use the matching rule
+.B matching_rule
+in all lookups for
+.B attribute
+attribute.
+If
+.B nss_ldap
+was built without schema mapping support, then this option
+is ignored.
+Matching rule can be specified either as numeric OID or using
+descriptive form. Provide only value itself without any colons (:).
+Note that
+.B caseExactMatch
+(or its numeric OID
+.B 2.5.13.5
+) matching rule can be used to enforce case sensitive lookup for
+attributes that are case insensitive by itself.
+.TP
 .B nss_schema <rfc2307bis|rfc2307>
 If the value of this option is
 .BR

--- a/util.c
+++ b/util.c
@@ -1234,6 +1234,11 @@ _nss_ldap_readconfig (ldap_config_t ** presult, char **buffer, size_t *buflen)
 	{
 	  do_parse_map_statement (result, v, MAP_DEFAULT);
 	}
+      else if (!strncasecmp (k, NSS_LDAP_KEY_MATCHING_RULE,
+			     strlen (NSS_LDAP_KEY_MATCHING_RULE)))
+	{
+	  do_parse_map_statement (result, v, MAP_MATCHING_RULE);
+	}
       else if (!strcasecmp (k, NSS_LDAP_KEY_INITGROUPS))
 	{
 	  if (!strcasecmp (v, "backlink"))

--- a/util.h
+++ b/util.h
@@ -50,6 +50,7 @@ NSS_STATUS _nss_ldap_dn2uid (const char *dn,
 #define NSS_LDAP_KEY_MAP_OBJECTCLASS    "nss_map_objectclass"
 #define NSS_LDAP_KEY_SET_OVERRIDE       "nss_override_attribute_value"
 #define NSS_LDAP_KEY_SET_DEFAULT        "nss_default_attribute_value"
+#define NSS_LDAP_KEY_MATCHING_RULE      "nss_matching_rule"
 
 #define NSS_LDAP_CONFIG_BUFSIZ		4096
 #define NSS_LDAP_KEY_HOST		"host"


### PR DESCRIPTION
Matching rules allow (among others) to enforce case sensitive lookup where attribute by itself is case insensitive. In particular `uid` is such an attribute.

Implementation is based on introducing a new map that stores matching rules to be used for specific attributes. It is used in configuration file as `nss_matching_rule <attribute> <matching_rule>` much the same as `nss_map_attribute`. Only in this case no entry for an attribute results in `NULL` being returned by `MR`/`MRM` macro (corresponding to `AT`/`ATM`). The matching rule can be specified by both name and OID. Without any colons (`:`).

A heavy change was required in `ldap-schema.c` in code building filters. The `snprintf` was no longer reasonable solution. Main source of difficulty was that if there is a matching rule corresponding filter fragment looks like
`<attribute>:<matching_rule>:`
while without matching rule it must be just
`<attribute>`
So beside adding matching rule itself also colons (`:`) have to be added.

Now this could have been solved earlier by requiring user to specify the matching rule with those colons in the first place. Or to add them along map entry for the matching rule. I considered the first approach to be bad from user point of view. Second approach would be reasonable but would require change in map building code used and somehow I didn't want that.

So finally the colons had to be added at the filter build time. This also seems most futureproof. For example now adding support for `dn` extension in lookup would be very simple.

Colons could be done with `snprintf` by using ability to specify field precision as an argument to `snprintf`. So when adding matching rule we would have to add 3 fields: first for colon, then for matching rule, and finally for the closing colon. For the colons we would pass fixed string `":"`. For the matching rule we would pass either the matching rule or fixed empty string (`""`) if there is no matching rule. And all three would have a parametric precision field that would be set to `0` if there is no matching rule and to actual values when there is a matching rule. (Actual values would be `1`, matching rule length and again `1` respectively.)

Yet that would result in complicating this even more while those calls were already quite complex. So instead I decided to use some macros. I don't like macros but they allowed to cleanly deal with attributes as "code tokens" rather than string. This way code building the expression is IMHO clean and simple. (Possibly it would be even more readable if macros had shorter names.)

By the way I have corrected superfluous `&` in `_nss_ldap_filt_getgrent`.