### PR TITLE
Align TLS option names on OpenLDAP documentation

### DIFF
--- a/ldap-nss.c
+++ b/ldap-nss.c
@@ -33,6 +33,7 @@ static char rcsId[] =
 #include <pthread.h>
 #endif
 
+#include <sys/param.h> /* for PATH_MAX */
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -524,6 +525,14 @@ __local_option (void *outvalue)
   (ldap_set_option (NULL, LDAP_OPT_X_TLS_REQUIRE_CERT, (__checkpeer__)))
 #else
 #define SET_TLS_REQUIRE_CERT(__conn__, __checkpeer__) \
+  (__local_option (NULL))
+#endif
+
+#if defined(HAVE_LDAP_SET_OPTION) && defined(LDAP_OPT_X_TLS_CRLCHECK)
+#define SET_TLS_CRLCHECK(__conn__, __crlcheck__) \
+  (ldap_set_option (NULL, LDAP_OPT_X_TLS_CRLCHECK, (__crlcheck__)))
+#else
+#define SET_TLS_CRLCHECK(__conn__, __crlcheck__) \
   (__local_option (NULL))
 #endif
 
@@ -2173,6 +2182,16 @@ do_ssl_options (ldap_config_t * cfg)
       if ((rc = SET_TLS_REQUIRE_CERT (NULL, &cfg->ldc_tls_checkpeer)) != LDAP_OPT_SUCCESS)
 	{
 	  debug ("<== do_ssl_options: Setting of LDAP_OPT_X_TLS_REQUIRE_CERT failed");
+	  return LDAP_OPERATIONS_ERROR;
+	}
+    }
+
+  /* require crl? */
+  if (cfg->ldc_tls_crlcheck > -1)
+    {
+      if ((rc = SET_TLS_CRLCHECK (NULL, &cfg->ldc_tls_crlcheck)) != LDAP_OPT_SUCCESS)
+	{
+	  debug ("<== do_ssl_options: Setting of LDAP_OPT_X_TLS_CRLCHECK failed");
 	  return LDAP_OPERATIONS_ERROR;
 	}
     }

--- a/ldap-nss.h
+++ b/ldap-nss.h
@@ -59,7 +59,11 @@
 #include <nss_dbdefs.h>
 #include <nsswitch.h>
 #elif defined(HAVE_NSS_H)
+#ifdef __NetBSD__
+#include <nsswitch.h> /* NSS like interface in nsswitch.h header */
+#else
 #include <nss.h>
+#endif
 #elif defined(HAVE_IRS_H)
 #include "irs-nss.h"
 #endif
@@ -332,6 +336,8 @@ struct ldap_config
   ldap_service_search_descriptor_t *ldc_sds[LM_NONE];
   /* tls check peer */
   int ldc_tls_checkpeer;
+  /* tls crl check */
+  int ldc_tls_crlcheck;
   /* tls ca certificate file */
   char *ldc_tls_cacertfile;
   /* tls ca certificate dir */

--- a/ldap-nss.h
+++ b/ldap-nss.h
@@ -59,11 +59,7 @@
 #include <nss_dbdefs.h>
 #include <nsswitch.h>
 #elif defined(HAVE_NSS_H)
-#ifdef __NetBSD__
-#include <nsswitch.h> /* NSS like interface in nsswitch.h header */
-#else
 #include <nss.h>
-#endif
 #elif defined(HAVE_IRS_H)
 #include "irs-nss.h"
 #endif


### PR DESCRIPTION
nss_ldap used names for some TLS options that were different than
what libldap uses and documents in ldap.conf(5). Using libldap
style names caused the option to be silently ignored, which created
a security hazard.
- tls_reqcert is now accepted as a synonym for tls_checkpeer.
  It now accept values: hard, demand, allow, try and never.
  on, yes, and true are still supported and mean hard.
  off, not and false are still supported and mean never.
- tls_cacert is now accepted as a synonym for tls_cacertfile.
- tls_cipher_suite is now accepted as a synonym for tls_ciphers
- While we are there, implement tls_crlcheck (none|peer|all)
