### PR TITLE
RFC 2307bis configurable DN search

### DIFF
--- a/ldap-nss.c
+++ b/ldap-nss.c
@@ -2426,6 +2426,7 @@ _nss_ldap_ent_context_init_locked (ent_context_t ** pctx)
 	}
     }
 
+  ctx->ec_session = &__session;
   ctx->ec_cookie = NULL;
   ctx->ec_res = NULL;
   ctx->ec_msgid = -1;

--- a/ldap-nss.h
+++ b/ldap-nss.h
@@ -107,6 +107,8 @@
 
 #define LDAP_NSS_MAXGR_DEPTH     16     /* maximum depth of group nesting for getgrent()/initgroups() */
 
+#define LDAP_NSS_ENTRYDN         "distinguishedName"
+
 #if LDAP_NSS_NGROUPS > 64
 #define LDAP_NSS_BUFLEN_GROUP	(NSS_BUFSIZ + (LDAP_NSS_NGROUPS * (sizeof (char *) + LOGNAME_MAX))) 
 #else
@@ -407,6 +409,8 @@ struct ldap_config
   time_t ldc_mtime;
 
   char **ldc_initgroups_ignoreusers;
+
+  char *ldc_entrydn;
 };
 
 typedef struct ldap_config ldap_config_t;
@@ -649,6 +653,7 @@ typedef struct ldap_state ldap_state_t;
  */
 struct ent_context
 {
+  ldap_session_t *ec_session;	/* LDAP session */
   ldap_state_t ec_state;	/* eg. for services */
   int ec_msgid;			/* message ID */
   LDAPMessage *ec_res;		/* result chain */

--- a/nss_ldap.5
+++ b/nss_ldap.5
@@ -480,6 +480,11 @@ rfc2307bis
 then support for the RFC2307bis schema (distinguished names in
 groups) will be enabled.
 .TP
+.B nss_entrydn <attribute>
+Specify how to search for DN when using the RFC2307bis schema.
+Default is dinstinguishedName, which fits Active Directory. 
+Use entryDN for OpenLDAP.
+.TP
 .B nss_initgroups <backlink>
 This option directs the
 .B nss_ldap

--- a/util.c
+++ b/util.c
@@ -672,6 +672,7 @@ NSS_STATUS _nss_ldap_init_config (ldap_config_t * result)
   result->ldc_reconnect_maxsleeptime = LDAP_NSS_MAXSLEEPTIME * USECSPERSEC;
   result->ldc_reconnect_maxconntries = LDAP_NSS_MAXCONNTRIES;
   result->ldc_initgroups_ignoreusers = NULL;
+  result->ldc_entrydn = LDAP_NSS_ENTRYDN;
 
   for (i = 0; i <= LM_NONE; i++)
     {
@@ -1249,6 +1250,10 @@ _nss_ldap_readconfig (ldap_config_t ** presult, char **buffer, size_t *buflen)
 	    {
 	      result->ldc_flags &= ~(NSS_LDAP_FLAGS_INITGROUPS_BACKLINK);
 	    }
+	}
+      else if (!strcasecmp (k, NSS_LDAP_KEY_ENTRYDN))
+	{
+	    t = &result->ldc_entrydn;
 	}
       else if (!strcasecmp (k, NSS_LDAP_KEY_SCHEMA))
 	{

--- a/util.h
+++ b/util.h
@@ -92,6 +92,7 @@ NSS_STATUS _nss_ldap_dn2uid (const char *dn,
 #define NSS_LDAP_KEY_DEBUG		"debug"
 #define NSS_LDAP_KEY_PAGESIZE		"pagesize"
 #define NSS_LDAP_KEY_INITGROUPS		"nss_initgroups"
+#define NSS_LDAP_KEY_ENTRYDN		"nss_entrydn"
 #define NSS_LDAP_KEY_INITGROUPS_IGNOREUSERS	"nss_initgroups_ignoreusers"
 #define NSS_LDAP_KEY_GETGRENT_SKIPMEMBERS	"nss_getgrent_skipmembers"
 


### PR DESCRIPTION
RFC 2307bis uses group DN and nss_ldap needs to search for them. Using distinguishedName works for Active Directory, and OpenLDAP use entryDN.

This change majes the attribute configurable, with the previous hardcoded value of distinguishedName being the default.